### PR TITLE
Add California Care Compass open data catalog

### DIFF
--- a/data/entities/US/US-CA/opendata/californiacarecompasscom.yaml
+++ b/data/entities/US/US-CA/opendata/californiacarecompasscom.yaml
@@ -1,0 +1,71 @@
+access_mode:
+- open
+api: false
+catalog_type: Open data portal
+content_types:
+- dataset
+coverage:
+- location:
+    country:
+      id: US
+      name: United States
+    level: 30
+    macroregion:
+      id: '021'
+      name: Northern America
+    subregion:
+      id: US-CA
+      name: California
+description: California senior-care data portal publishing downloadable cost-planning
+  ranges and Assisted Living Waiver facility, capacity, enrollment, and waitlist data
+  with government-source provenance and reuse metadata.
+id: californiacarecompasscom
+langs:
+- id: EN
+  name: English
+link: https://californiacarecompass.com/data
+name: California Care Compass Open Data
+owner:
+  link: https://californiacarecompass.com
+  location:
+    country:
+      id: US
+      name: United States
+    level: 30
+    subregion:
+      id: US-CA
+      name: California
+  name: California Care Compass
+  type: Private sector
+properties:
+  has_doi: false
+  transferable_location: true
+  transferable_topics: true
+rights:
+  license_id: CC-BY-4.0
+  license_name: Creative Commons Attribution 4.0 International
+  license_url: https://creativecommons.org/licenses/by/4.0/
+  privacy_policy_url: https://californiacarecompass.com/privacy
+  rights_type: granular
+  tos_url: https://californiacarecompass.com/terms
+software:
+  id: custom
+  name: Custom software
+status: active
+tags:
+- open data
+- California
+- senior care
+- long-term care
+- assisted living
+- Assisted Living Waiver
+- Medi-Cal
+- healthcare
+topics:
+- id: HEAL
+  name: Health
+  type: eudatatheme
+- id: Health
+  name: Health
+  type: iso19115
+uid: cdi00021933


### PR DESCRIPTION
Implements #99 by adding the California Care Compass data portal as a California (US-CA) open data catalog.

The record classifies the owner as private sector, the software as custom, and the catalog topic as health. It documents open access and granular CC BY 4.0 dataset licensing without representing the portal as governmental or claiming a catalog API.

The portal publishes two directly downloadable California senior-care datasets with source provenance: regional cost-planning ranges and a DHCS-derived Assisted Living Waiver tracker.

Validation:
- `.venv/bin/python scripts/builder.py validate-yaml`
- `.venv/bin/pytest --no-cov -q` (196 passed)