### PR TITLE
Add TechRole Index open data catalog

### DIFF
--- a/data/entities/RU/Federal/indicators/techroleru.yaml
+++ b/data/entities/RU/Federal/indicators/techroleru.yaml
@@ -1,0 +1,74 @@
+access_mode:
+- open
+api: true
+api_status: active
+catalog_type: Indicators catalog
+catalog_export: DCAT 3
+content_types:
+- indicator
+- dataset
+coverage:
+- location:
+    country:
+      id: RU
+      name: Russian Federation
+    level: 20
+    macroregion:
+      id: '151'
+      name: Eastern Europe
+description: TechRole Index publishes reproducible daily aggregates of IT vacancy
+  publications in Russia by profession, seniority, region, salary tax status and
+  currency. The catalog provides JSON and CSV distributions with JSON Schema, CSVW,
+  Croissant 1.1, DCAT 3, Frictionless Data Package and provenance metadata.
+endpoints:
+- type: dcat:jsonld
+  url: https://techrole.ru/catalog.jsonld
+  version: '3'
+- type: data-package
+  url: https://techrole.ru/datapackage.json
+identifiers:
+- id: doi
+  url: https://doi.org/10.5281/zenodo.21559744
+  value: 10.5281/zenodo.21559744
+id: techroleru
+langs:
+- id: RU
+  name: Russian
+link: https://techrole.ru/open-data-daily
+name: TechRole Index Open Data
+owner:
+  link: https://techrole.ru/about
+  location:
+    country:
+      id: RU
+      name: Russian Federation
+    level: 20
+  name: TechRole Index
+  type: Business
+properties:
+  has_doi: true
+  is_national: true
+rights:
+  license_id: Russian-Federal-Open-Data-Terms
+  license_name: Russian Federation Standard Open Data Terms
+  license_url: https://rospatent.gov.ru/ru/opendata/uslovia-od
+  rights_type: granular
+software:
+  id: custom
+  name: Custom software
+status: active
+tags:
+- IT professions
+- job postings
+- labor market
+- salaries
+- open data
+- has_api
+topics:
+- id: ECON
+  name: Economy and finance
+  type: eudatatheme
+- id: SOCI
+  name: Population and society
+  type: eudatatheme
+uid: cdi99990001


### PR DESCRIPTION
## Summary

Adds **TechRole Index Open Data** as an active Russian federal indicators catalog.

The entry describes a catalog rather than a single file: its canonical page publishes a maintained collection of daily IT-vacancy publication aggregates and exposes JSON/CSV distributions plus DCAT 3, Frictionless Data Package, CSVW, JSON Schema and Croissant metadata. The catalog covers Russian labour-market indicators by profession, seniority, region, salary tax status and currency.

Evidence:
- Catalog: https://techrole.ru/open-data-daily
- DCAT 3: https://techrole.ru/catalog.jsonld
- Data Package: https://techrole.ru/datapackage.json
- Methodology: https://techrole.ru/methodology
- Archived release / DOI: https://doi.org/10.5281/zenodo.21559744
- Source terms: https://rospatent.gov.ru/ru/opendata/uslovia-od

A repository code search for `techrole.ru` returned no existing entry.

## Change type

- [x] New or updated catalog YAML(s)
- [ ] Data quality / fix script
- [ ] Build or validation pipeline
- [ ] Documentation only
- [ ] Other

## Checklist

- [x] YAML `id` matches filename (lowercase, no special characters)
- [ ] Ran `python scripts/builder.py validate-yaml` (or validated affected file(s))
- [ ] If bulk quality fixes: ran `analyze-quality` and updated `dataquality/baseline_counts.json` when priority counts changed
- [x] Tests pass locally (not applicable: data-only addition; no code changes)

## Validation note

The entry was checked field-by-field against the current Cerberus schema and the existing Russian indicators examples. Repository CI is expected to run the canonical validator on the submitted change.
