### PR TITLE
Add BaanScope Open Data (TH) — Thai new-build housing datasets

### DIFF
--- a/data/entities/TH/Federal/opendata/baanscopecom.yaml
+++ b/data/entities/TH/Federal/opendata/baanscopecom.yaml
@@ -1,0 +1,70 @@
+access_mode:
+- open
+api: false
+api_status: uncertain
+catalog_type: Datasets list
+content_types:
+- dataset
+coverage:
+- location:
+    country:
+      id: TH
+      name: Thailand
+    level: 20
+    macroregion:
+      id: '035'
+      name: South-eastern Asia
+description: Aggregate open datasets derived from BaanScope's tracked pipeline of new-build
+  residential projects by Thailand's nine largest SET-listed developers. Three cuts are
+  published, by Bangkok-metro district, by developer and by completion year, each with a
+  column dictionary. Files are served as CSV and JSON under CC BY 4.0 with permissive CORS
+  headers, need no sign-up or API key, and are regenerated on every site build.
+id: baanscopecom
+langs:
+- id: EN
+  name: English
+- id: TH
+  name: Thai
+- id: ZH
+  name: Chinese
+link: https://baanscope.com/data
+name: BaanScope Open Data
+owner:
+  link: https://baanscope.com
+  location:
+    country:
+      id: TH
+      name: Thailand
+    level: 20
+  name: BaanScope
+  type: Business
+properties:
+  has_doi: false
+  is_national: false
+rights:
+  license_id: CC-BY-4.0
+  license_name: Creative Commons Attribution 4.0 International
+  license_url: https://creativecommons.org/licenses/by/4.0/
+  privacy_policy_url: null
+  rights_type: global
+  tos_url: null
+software:
+  id: custom
+  name: Custom software
+status: active
+tags:
+- housing
+- real estate
+- construction
+- property
+- bangkok
+- thailand
+- open data
+topics:
+- id: ECON
+  name: Economy and finance
+  type: eudatatheme
+- id: REGI
+  name: Regions and cities
+  type: eudatatheme
+uid: cdi00022512


### PR DESCRIPTION
Adds one entry: `data/entities/TH/Federal/opendata/baanscopecom.yaml`.

### What it is

[BaanScope Open Data](https://baanscope.com/data) publishes aggregate cuts of Thailand’s new-build residential pipeline, compiled from the nine largest SET-listed developers (SC Asset, Land & Houses, AssetWise, AP Thai, Origin, Sansiri, Supalai, Noble, Pruksa). Three datasets, each with a published column dictionary:

| Dataset | Rows × cols | CSV | JSON |
|---|---|---|---|
| Pipeline by district | 104 × 11 | `/data/districts.csv` | `/data/districts.json` |
| Pipeline by developer | 9 × 11 | `/data/developers.csv` | `/data/developers.json` |
| Completion wave | by year × 8 | `/data/completion-wave.csv` | `/data/completion-wave.json` |

- **Licence:** CC BY 4.0, stated on the landing page.
- **Access:** no sign-up, no API key. All six files return HTTP 200 with `Access-Control-Allow-Origin: *`, so notebooks can fetch them directly.
- **Freshness:** the files are build-time artifacts regenerated on every site build, so they cannot drift from what the site renders.

### Field choices, and one I would like a second opinion on

- `catalog_type: Datasets list` rather than `Open data portal` — it is a landing page listing a fixed set of downloadable files, not a searchable portal. `Datasets list` seemed the honest fit, but happy to change it.
- `owner.type: Business` — this is a private-sector publisher, not a government body. That is why it sits in `TH/Federal/opendata/` alongside the government portals rather than in a category of its own; `marketplace` and `other` do not exist under `TH/` yet and neither seemed right. **If you would prefer a different placement, say so and I will move it.**
- `api: false` / `api_status: uncertain` — there are no API endpoints, only static files, so no `endpoints` block.
- `uid: cdi00022512` — next free value above the current maximum (`cdi00022511`).

### Validation

`python scripts/builder.py validate-yaml` reports no errors on this file (the 11 errors it reports are pre-existing, in US/IT/PT/FR/EU records, none touched here). `analyze-quality` flags nothing for this entry. No duplicate: nothing else in `data/` references this domain.

### Disclosure

I maintain BaanScope. Submitting it here because it matches what the registry indexes — a licensed, machine-readable, CORS-enabled dataset with a landing page — but I am obviously not a neutral party, so please apply whatever scrutiny that warrants.